### PR TITLE
fix silence trimming for flac files

### DIFF
--- a/libmp3splt/plugins/flac_silence.c
+++ b/libmp3splt/plugins/flac_silence.c
@@ -251,6 +251,11 @@ static void splt_flac_scan_silence_and_process(splt_state *state, off_t start_of
     }
   }
 
+  int junk;
+  int err = SPLT_OK;
+  process_silence(-1, -96, SPLT_FALSE, SPLT_FALSE, ssd, &junk, &err);
+  if (err < 0) { *error = err; }
+    
   if (silence_data->error < 0)
   {
     *error = silence_data->error;


### PR DESCRIPTION
The FLAC plugin doesn't process the last frames while using the trim silence option, which means it only ever detects one splitpoint (and thus fails to write anything). I copied this code snippet over from the mp3 plugin to fix this. No idea if this breaks anything else, but in the specific case of trimming silence from FLAC files, it seems to work.

Headers for the file are probably gonna be messed up, though -- I'd recommend a round of `ffmpeg -i <filename>.flac -c:a flac <filename>_reencode.flac` afterwards. But the audio data seems intact!