### PR TITLE
fixed prototype for splt_ogg_new_stream_needs_header_packet with gcc 15

### DIFF
--- a/libmp3splt/plugins/ogg_new_stream_handler.h
+++ b/libmp3splt/plugins/ogg_new_stream_handler.h
@@ -61,7 +61,7 @@ void splt_ogg_nsh_free(splt_ogg_new_stream_handler **nsh);
 
 void splt_ogg_initialise_for_new_stream(splt_ogg_new_stream_handler *nsh, 
     ogg_page *page, ogg_int64_t *cutpoint, ogg_int64_t previous_granulepos);
-int splt_ogg_new_stream_needs_header_packet();
+int splt_ogg_new_stream_needs_header_packet(splt_ogg_new_stream_handler *nsh);
 void splt_ogg_new_stream_handle_header_packet(splt_ogg_new_stream_handler *nsh, ogg_packet *packet, int *error);
 
 #define MP3SPLT_OGG_NEW_STREAM_HANDLER_H


### PR DESCRIPTION
This is the libmp3splt counterpart for #373.

Hotfixed downstreams, see https://aur.archlinux.org/packages/libmp3splt